### PR TITLE
Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target/
+Cargo.lock
+**/*.rs.bk


### PR DESCRIPTION
This adds the default recommended `.gitignore` files for Cargo libraries.