### PR TITLE
Minor (potential) improvements

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -24,12 +24,10 @@
 //! (On Windows, `OsStr` uses 16 bit wide characters so this will not work.)
 
 extern crate alloc;
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
-#[cfg(test)]
-use alloc::vec;
-#[cfg(test)]
-use alloc::borrow::ToOwned;
+use alloc::vec::Vec;
+
+type StaticByteString = &'static [u8];
 
 /// An iterator that takes an input byte string and splits it into the words using the same syntax as
 /// the POSIX shell.
@@ -57,24 +55,40 @@ impl<'a> Shlex<'a> {
         let mut result: Vec<u8> = Vec::new();
         loop {
             match ch as char {
-                '"' => if let Err(()) = self.parse_double(&mut result) {
-                    self.had_error = true;
-                    return None;
-                },
-                '\'' => if let Err(()) = self.parse_single(&mut result) {
-                    self.had_error = true;
-                    return None;
-                },
-                '\\' => if let Some(ch2) = self.next_char() {
-                    if ch2 != '\n' as u8 { result.push(ch2); }
-                } else {
-                    self.had_error = true;
-                    return None;
-                },
-                ' ' | '\t' | '\n' => { break; },
-                _ => { result.push(ch as u8); },
+                '"' => {
+                    if let Err(()) = self.parse_double(&mut result) {
+                        self.had_error = true;
+                        return None;
+                    }
+                }
+                '\'' => {
+                    if let Err(()) = self.parse_single(&mut result) {
+                        self.had_error = true;
+                        return None;
+                    }
+                }
+                '\\' => {
+                    if let Some(ch2) = self.next_char() {
+                        if ch2 != b'\n' {
+                            result.push(ch2);
+                        }
+                    } else {
+                        self.had_error = true;
+                        return None;
+                    }
+                }
+                ' ' | '\t' | '\n' => {
+                    break;
+                }
+                _ => {
+                    result.push(ch);
+                }
             }
-            if let Some(ch2) = self.next_char() { ch = ch2; } else { break; }
+            if let Some(ch2) = self.next_char() {
+                ch = ch2;
+            } else {
+                break;
+            }
         }
         Some(result)
     }
@@ -87,18 +101,27 @@ impl<'a> Shlex<'a> {
                         if let Some(ch3) = self.next_char() {
                             match ch3 as char {
                                 // \$ => $
-                                '$' | '`' | '"' | '\\' => { result.push(ch3); },
+                                '$' | '`' | '"' | '\\' => {
+                                    result.push(ch3);
+                                }
                                 // \<newline> => nothing
-                                '\n' => {},
+                                '\n' => {}
                                 // \x => =x
-                                _ => { result.push('\\' as u8); result.push(ch3); }
+                                _ => {
+                                    result.push(b'\\');
+                                    result.push(ch3);
+                                }
                             }
                         } else {
                             return Err(());
                         }
-                    },
-                    '"' => { return Ok(()); },
-                    _ => { result.push(ch2); },
+                    }
+                    '"' => {
+                        return Ok(());
+                    }
+                    _ => {
+                        result.push(ch2);
+                    }
                 }
             } else {
                 return Err(());
@@ -109,9 +132,13 @@ impl<'a> Shlex<'a> {
     fn parse_single(&mut self, result: &mut Vec<u8>) -> Result<(), ()> {
         loop {
             if let Some(ch2) = self.next_char() {
-                match ch2 as char {
-                    '\'' => { return Ok(()); },
-                    _ => { result.push(ch2); },
+                match ch2 {
+                    b'\'' => {
+                        return Ok(());
+                    }
+                    _ => {
+                        result.push(ch2);
+                    }
                 }
             } else {
                 return Err(());
@@ -121,7 +148,9 @@ impl<'a> Shlex<'a> {
 
     fn next_char(&mut self) -> Option<u8> {
         let res = self.in_iter.next().copied();
-        if res == Some(b'\n') { self.line_no += 1; }
+        if res == Some(b'\n') {
+            self.line_no += 1;
+        }
         res
     }
 }
@@ -133,30 +162,42 @@ impl<'a> Iterator for Shlex<'a> {
             // skip initial whitespace
             loop {
                 match ch as char {
-                    ' ' | '\t' | '\n' => {},
+                    ' ' | '\t' | '\n' => {}
                     '#' => {
                         while let Some(ch2) = self.next_char() {
-                            if ch2 as char == '\n' { break; }
+                            if ch2 as char == '\n' {
+                                break;
+                            }
                         }
-                    },
-                    _ => { break; }
+                    }
+                    _ => {
+                        break;
+                    }
                 }
-                if let Some(ch2) = self.next_char() { ch = ch2; } else { return None; }
+                if let Some(ch2) = self.next_char() {
+                    ch = ch2;
+                } else {
+                    return None;
+                }
             }
             self.parse_word(ch)
-        } else { // no initial character
+        } else {
+            // no initial character
             None
         }
     }
-
 }
 
 /// Convenience function that consumes the whole byte string at once.  Returns None if the input was
 /// erroneous.
-pub fn split(in_bytes: &[u8]) -> Option<Vec<Vec<u8>>> {
+pub fn split(in_bytes: StaticByteString) -> Option<Vec<Vec<u8>>> {
     let mut shl = Shlex::new(in_bytes);
     let res = shl.by_ref().collect();
-    if shl.had_error { None } else { Some(res) }
+    if shl.had_error {
+        None
+    } else {
+        Some(res)
+    }
 }
 
 /// Given a single word, return a byte string suitable to encode it as a shell argument.
@@ -166,19 +207,17 @@ pub fn split(in_bytes: &[u8]) -> Option<Vec<Vec<u8>>> {
 /// returns two double quotes if the input was an empty string). It will never modify a
 /// multibyte UTF-8 character.
 pub fn quote(in_bytes: &[u8]) -> Cow<[u8]> {
-    if in_bytes.len() == 0 {
+    let special_chars = b"|&;<>()$`\\\"\' \t\r\n*?[#~=%";
+
+    if in_bytes.is_empty() {
         b"\"\""[..].into()
-    } else if in_bytes.iter().any(|c| match *c as char {
-        '|' | '&' | ';' | '<' | '>' | '(' | ')' | '$' | '`' | '\\' | '"' | '\'' | ' ' | '\t' |
-        '\r' | '\n' | '*' | '?' | '[' | '#' | '~' | '=' | '%' => true,
-        _ => false
-    }) {
+    } else if in_bytes.iter().any(|c| special_chars.contains(c)) {
         let mut out: Vec<u8> = Vec::new();
         out.push(b'"');
         for &c in in_bytes {
             match c {
                 b'$' | b'`' | b'"' | b'\\' => out.push(b'\\'),
-                _ => ()
+                _ => (),
             }
             out.push(c);
         }
@@ -192,77 +231,85 @@ pub fn quote(in_bytes: &[u8]) -> Cow<[u8]> {
 /// Convenience function that consumes an iterable of words and turns it into a single byte string,
 /// quoting words when necessary. Consecutive words will be separated by a single space.
 pub fn join<'a, I: core::iter::IntoIterator<Item = &'a [u8]>>(words: I) -> Vec<u8> {
-    words.into_iter()
-        .map(quote)
-        .collect::<Vec<_>>()
-        .join(&b' ')
+    words.into_iter().map(quote).collect::<Vec<_>>().join(&b' ')
 }
 
 #[cfg(test)]
-const INVALID_UTF8: &[u8] = b"\xa1";
+mod test {
+    use alloc::borrow::ToOwned;
+    use alloc::vec;
 
-#[test]
-fn test_invalid_utf8() {
-    // Check that our test string is actually invalid UTF-8.
-    assert!(core::str::from_utf8(INVALID_UTF8).is_err());
-}
+    use super::*;
 
-#[cfg(test)]
-static SPLIT_TEST_ITEMS: &'static [(&'static [u8], Option<&'static [&'static [u8]]>)] = &[
-    (b"foo$baz", Some(&[b"foo$baz"])),
-    (b"foo baz", Some(&[b"foo", b"baz"])),
-    (b"foo\"bar\"baz", Some(&[b"foobarbaz"])),
-    (b"foo \"bar\"baz", Some(&[b"foo", b"barbaz"])),
-    (b"   foo \nbar", Some(&[b"foo", b"bar"])),
-    (b"foo\\\nbar", Some(&[b"foobar"])),
-    (b"\"foo\\\nbar\"", Some(&[b"foobar"])),
-    (b"'baz\\$b'", Some(&[b"baz\\$b"])),
-    (b"'baz\\\''", None),
-    (b"\\", None),
-    (b"\"\\", None),
-    (b"'\\", None),
-    (b"\"", None),
-    (b"'", None),
-    (b"foo #bar\nbaz", Some(&[b"foo", b"baz"])),
-    (b"foo #bar", Some(&[b"foo"])),
-    (b"foo#bar", Some(&[b"foo#bar"])),
-    (b"foo\"#bar", None),
-    (b"'\\n'", Some(&[b"\\n"])),
-    (b"'\\\\n'", Some(&[b"\\\\n"])),
-    (INVALID_UTF8, Some(&[INVALID_UTF8])),
-];
+    const INVALID_UTF8: StaticByteString = b"\xa1";
+    static SPLIT_TEST_ITEMS: &[(StaticByteString, Option<&[StaticByteString]>)] = &[
+        (b"foo$baz", Some(&[b"foo$baz"])),
+        (b"foo baz", Some(&[b"foo", b"baz"])),
+        (b"foo\"bar\"baz", Some(&[b"foobarbaz"])),
+        (b"foo \"bar\"baz", Some(&[b"foo", b"barbaz"])),
+        (b"   foo \nbar", Some(&[b"foo", b"bar"])),
+        (b"foo\\\nbar", Some(&[b"foobar"])),
+        (b"\"foo\\\nbar\"", Some(&[b"foobar"])),
+        (b"'baz\\$b'", Some(&[b"baz\\$b"])),
+        (b"'baz\\\''", None),
+        (b"\\", None),
+        (b"\"\\", None),
+        (b"'\\", None),
+        (b"\"", None),
+        (b"'", None),
+        (b"foo #bar\nbaz", Some(&[b"foo", b"baz"])),
+        (b"foo #bar", Some(&[b"foo"])),
+        (b"foo#bar", Some(&[b"foo#bar"])),
+        (b"foo\"#bar", None),
+        (b"'\\n'", Some(&[b"\\n"])),
+        (b"'\\\\n'", Some(&[b"\\\\n"])),
+        (INVALID_UTF8, Some(&[INVALID_UTF8])),
+    ];
 
-#[test]
-fn test_split() {
-    for &(input, output) in SPLIT_TEST_ITEMS {
-        assert_eq!(split(input), output.map(|o| o.iter().map(|&x| x.to_owned()).collect()));
+    #[test]
+    fn test_invalid_utf8() {
+        // Check that our test string is actually invalid UTF-8.
+        assert!(core::str::from_utf8(INVALID_UTF8).is_err());
     }
-}
 
-#[test]
-fn test_lineno() {
-    let mut sh = Shlex::new(b"\nfoo\nbar");
-    while let Some(word) = sh.next() {
-        if word == b"bar" {
-            assert_eq!(sh.line_no, 3);
+    #[test]
+    fn test_split() {
+        for &(input, output) in SPLIT_TEST_ITEMS {
+            assert_eq!(
+                split(input),
+                output.map(|o| o.iter().map(|&x| x.to_owned()).collect())
+            );
         }
     }
-}
 
-#[test]
-fn test_quote() {
-    assert_eq!(quote(b"foobar"), &b"foobar"[..]);
-    assert_eq!(quote(b"foo bar"), &b"\"foo bar\""[..]);
-    assert_eq!(quote(b"\""), &b"\"\\\"\""[..]);
-    assert_eq!(quote(b""), &b"\"\""[..]);
-    assert_eq!(quote(INVALID_UTF8), INVALID_UTF8);
-}
+    #[test]
+    fn test_lineno() {
+        let mut sh = Shlex::new(b"\nfoo\nbar");
+        while let Some(word) = sh.next() {
+            if word == b"bar" {
+                assert_eq!(sh.line_no, 3);
+            }
+        }
+    }
 
-#[test]
-fn test_join() {
-    assert_eq!(join(vec![]), &b""[..]);
-    assert_eq!(join(vec![&b""[..]]), &b"\"\""[..]);
-    assert_eq!(join(vec![&b"a"[..], &b"b"[..]]), &b"a b"[..]);
-    assert_eq!(join(vec![&b"foo bar"[..], &b"baz"[..]]), &b"\"foo bar\" baz"[..]);
-    assert_eq!(join(vec![INVALID_UTF8]), INVALID_UTF8);
+    #[test]
+    fn test_quote() {
+        assert_eq!(quote(b"foobar"), &b"foobar"[..]);
+        assert_eq!(quote(b"foo bar"), &b"\"foo bar\""[..]);
+        assert_eq!(quote(b"\""), &b"\"\\\"\""[..]);
+        assert_eq!(quote(b""), &b"\"\""[..]);
+        assert_eq!(quote(INVALID_UTF8), INVALID_UTF8);
+    }
+
+    #[test]
+    fn test_join() {
+        assert_eq!(join(vec![]), &b""[..]);
+        assert_eq!(join(vec![&b""[..]]), &b"\"\""[..]);
+        assert_eq!(join(vec![&b"a"[..], &b"b"[..]]), &b"a b"[..]);
+        assert_eq!(
+            join(vec![&b"foo bar"[..], &b"baz"[..]]),
+            &b"\"foo bar\" baz"[..]
+        );
+        assert_eq!(join(vec![INVALID_UTF8]), INVALID_UTF8);
+    }
 }


### PR DESCRIPTION
Feel free to decide if this is even necessary but these are the changes in this small PR:

- Format using `rustfmt`
- Fix `clippy` warnings
- Put all tests in separate modules

I suppose the main thing is the tests going into modules, as that cleans up the test specific imports and puts all tests behind a `#[cfg(test)]` attribute which should keep all those test functions from needing to be included in the final compilation even when not testing. This seemed to lead to saving an admittedly tiny 2k (48k to 46k) from the `libshlex.rlib` with `cargo build --lib --release` on my machine.