### PR TITLE
Remove unsound API and existing deprecated items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# 1.3.1
+# 2.0.0
 
-* Trivial improvements.
+* **Breaking:** Items that were marked as deprecated in 1.x have been removed: `join`, `quote`, `bytes::join`, and `bytes::quote`.
 
 # 1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.0.0
 
 * **Breaking:** Items that were marked as deprecated in 1.x have been removed: `join`, `quote`, `bytes::join`, and `bytes::quote`.
+* **Breaking:** The `DerefMut` impl for `Shlex` has been removed since it was unsound. New `unsafe` APIs have been added in its place: `Shlex::from_bytes`, `Shlex::as_bytes_mut`.
 
 # 1.3.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shlex"
-version = "1.3.1"
+version = "2.0.0"
 authors = [
     "comex <comexk@gmail.com>",
     "Fenhl <fenhl@fenhl.net>",

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -27,8 +27,6 @@ extern crate alloc;
 use alloc::vec::Vec;
 use alloc::borrow::Cow;
 #[cfg(test)]
-use alloc::vec;
-#[cfg(test)]
 use alloc::borrow::ToOwned;
 #[cfg(all(doc, not(doctest)))]
 use crate::{self as shlex, quoting_warning};
@@ -467,8 +465,6 @@ pub fn try_quote(in_bytes: &[u8]) -> Result<Cow<'_, [u8]>, QuoteError> {
 
 #[cfg(test)]
 const INVALID_UTF8: &[u8] = b"\xa1";
-#[cfg(test)]
-const INVALID_UTF8_SINGLEQUOTED: &[u8] = b"'\xa1'";
 
 #[test]
 #[allow(invalid_from_utf8)]

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -11,13 +11,13 @@
 //!
 //! ```rust
 //! #[cfg(unix)] {
-//!     use shlex::bytes::quote;
+//!     use shlex::bytes::try_quote;
 //!     use std::ffi::OsStr;
 //!     use std::os::unix::ffi::OsStrExt;
 //!
 //!     // `\x80` is invalid in UTF-8.
 //!     let os_str = OsStr::from_bytes(b"a\x80b c");
-//!     assert_eq!(quote(os_str.as_bytes()), &b"'a\x80b c'"[..]);
+//!     assert_eq!(try_quote(os_str.as_bytes()).unwrap(), &b"'a\x80b c'"[..]);
 //! }
 //! ```
 //!

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -445,23 +445,7 @@ fn append_quoted_chunk(out: &mut Vec<u8>, cur_chunk: &[u8], strategy: QuotingStr
 /// Convenience function that consumes an iterable of words and turns it into a single byte string,
 /// quoting words when necessary. Consecutive words will be separated by a single space.
 ///
-/// Uses default settings except that nul bytes are passed through, which [may be
-/// dangerous](quoting_warning#nul-bytes), leading to this function being deprecated.
-///
-/// Equivalent to [`Quoter::new().allow_nul(true).join(words).unwrap()`](Quoter).
-///
-/// (That configuration never returns `Err`, so this function does not panic.)
-///
-/// The string equivalent is [shlex::join].
-#[deprecated(since = "1.3.0", note = "replace with `try_join(words)?` to avoid nul byte danger")]
-pub fn join<'a, I: IntoIterator<Item = &'a [u8]>>(words: I) -> Vec<u8> {
-    Quoter::new().allow_nul(true).join(words).unwrap()
-}
-
-/// Convenience function that consumes an iterable of words and turns it into a single byte string,
-/// quoting words when necessary. Consecutive words will be separated by a single space.
-///
-/// Uses default settings.  The only error that can be returned is [`QuoteError::Nul`].
+/// Uses default settings. The only error that can be returned is [`QuoteError::Nul`].
 ///
 /// Equivalent to [`Quoter::new().join(words)`](Quoter).
 ///
@@ -472,26 +456,9 @@ pub fn try_join<'a, I: IntoIterator<Item = &'a [u8]>>(words: I) -> Result<Vec<u8
 
 /// Given a single word, return a string suitable to encode it as a shell argument.
 ///
-/// Uses default settings except that nul bytes are passed through, which [may be
-/// dangerous](quoting_warning#nul-bytes), leading to this function being deprecated.
-///
-/// Equivalent to [`Quoter::new().allow_nul(true).quote(in_bytes).unwrap()`](Quoter).
-///
-/// (That configuration never returns `Err`, so this function does not panic.)
-///
-/// The string equivalent is [shlex::quote].
-#[deprecated(since = "1.3.0", note = "replace with `try_quote(str)?` to avoid nul byte danger")]
-pub fn quote(in_bytes: &[u8]) -> Cow<'_, [u8]> {
-    Quoter::new().allow_nul(true).quote(in_bytes).unwrap()
-}
-
-/// Given a single word, return a string suitable to encode it as a shell argument.
-///
-/// Uses default settings.  The only error that can be returned is [`QuoteError::Nul`].
+/// Uses default settings. The only error that can be returned is [`QuoteError::Nul`].
 ///
 /// Equivalent to [`Quoter::new().quote(in_bytes)`](Quoter).
-///
-/// (That configuration never returns `Err`, so this function does not panic.)
 ///
 /// The string equivalent is [shlex::try_quote].
 pub fn try_quote(in_bytes: &[u8]) -> Result<Cow<'_, [u8]>, QuoteError> {
@@ -550,27 +517,4 @@ fn test_lineno() {
             assert_eq!(sh.line_no, 3);
         }
     }
-}
-
-#[test]
-#[allow(deprecated)]
-fn test_quote() {
-    // Validate behavior with invalid UTF-8:
-    assert_eq!(quote(INVALID_UTF8), INVALID_UTF8_SINGLEQUOTED);
-    // Replicate a few tests from lib.rs.  No need to replicate all of them.
-    assert_eq!(quote(b""), &b"''"[..]);
-    assert_eq!(quote(b"foobar"), &b"foobar"[..]);
-    assert_eq!(quote(b"foo bar"), &b"'foo bar'"[..]);
-    assert_eq!(quote(b"'\""), &b"\"'\\\"\""[..]);
-    assert_eq!(quote(b""), &b"''"[..]);
-}
-
-#[test]
-#[allow(deprecated)]
-fn test_join() {
-    // Validate behavior with invalid UTF-8:
-    assert_eq!(join(vec![INVALID_UTF8]), INVALID_UTF8_SINGLEQUOTED);
-    // Replicate a few tests from lib.rs.  No need to replicate all of them.
-    assert_eq!(join(vec![]), &b""[..]);
-    assert_eq!(join(vec![&b""[..]]), b"''");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,23 +189,7 @@ impl From<Quoter> for bytes::Quoter {
 /// Convenience function that consumes an iterable of words and turns it into a single string,
 /// quoting words when necessary. Consecutive words will be separated by a single space.
 ///
-/// Uses default settings except that nul bytes are passed through, which [may be
-/// dangerous](quoting_warning#nul-bytes), leading to this function being deprecated.
-///
-/// Equivalent to [`Quoter::new().allow_nul(true).join(words).unwrap()`](Quoter).
-///
-/// (That configuration never returns `Err`, so this function does not panic.)
-///
-/// The bytes equivalent is [bytes::join].
-#[deprecated(since = "1.3.0", note = "replace with `try_join(words)?` to avoid nul byte danger")]
-pub fn join<'a, I: IntoIterator<Item = &'a str>>(words: I) -> String {
-    Quoter::new().allow_nul(true).join(words).unwrap()
-}
-
-/// Convenience function that consumes an iterable of words and turns it into a single string,
-/// quoting words when necessary. Consecutive words will be separated by a single space.
-///
-/// Uses default settings.  The only error that can be returned is [`QuoteError::Nul`].
+/// Uses default settings. The only error that can be returned is [`QuoteError::Nul`].
 ///
 /// Equivalent to [`Quoter::new().join(words)`](Quoter).
 ///
@@ -216,26 +200,9 @@ pub fn try_join<'a, I: IntoIterator<Item = &'a str>>(words: I) -> Result<String,
 
 /// Given a single word, return a string suitable to encode it as a shell argument.
 ///
-/// Uses default settings except that nul bytes are passed through, which [may be
-/// dangerous](quoting_warning#nul-bytes), leading to this function being deprecated.
-///
-/// Equivalent to [`Quoter::new().allow_nul(true).quote(in_str).unwrap()`](Quoter).
-///
-/// (That configuration never returns `Err`, so this function does not panic.)
-///
-/// The bytes equivalent is [bytes::quote].
-#[deprecated(since = "1.3.0", note = "replace with `try_quote(str)?` to avoid nul byte danger")]
-pub fn quote(in_str: &str) -> Cow<'_, str> {
-    Quoter::new().allow_nul(true).quote(in_str).unwrap()
-}
-
-/// Given a single word, return a string suitable to encode it as a shell argument.
-///
-/// Uses default settings.  The only error that can be returned is [`QuoteError::Nul`].
+/// Uses default settings. The only error that can be returned is [`QuoteError::Nul`].
 ///
 /// Equivalent to [`Quoter::new().quote(in_str)`](Quoter).
-///
-/// (That configuration never returns `Err`, so this function does not panic.)
 ///
 /// The bytes equivalent is [bytes::try_quote].
 pub fn try_quote(in_str: &str) -> Result<Cow<'_, str>, QuoteError> {
@@ -340,15 +307,6 @@ fn test_quote() {
         }
     }
     assert!(ok);
-}
-
-#[test]
-#[allow(deprecated)]
-fn test_join() {
-    assert_eq!(join(vec![]), "");
-    assert_eq!(join(vec![""]), "''");
-    assert_eq!(join(vec!["a", "b"]), "a b");
-    assert_eq!(join(vec!["foo bar", "baz"]), "'foo bar' baz");
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,20 @@ impl<'a> Shlex<'a> {
     pub fn new(in_str: &'a str) -> Self {
         Self(bytes::Shlex::new(in_str.as_bytes()))
     }
+
+    /// # Safety
+    ///
+    /// The parameter must have been constructed from valid UTF-8.
+    pub unsafe fn from_bytes(bytes: bytes::Shlex<'a>) -> Self {
+        Self(bytes)
+    }
+
+    /// # Safety
+    ///
+    /// If the returned reference is reassigned, the new [`bytes::Shlex`] must have been constructed from valid UTF-8.
+    pub unsafe fn as_bytes_mut(&mut self) -> &mut bytes::Shlex<'a> {
+        &mut self.0
+    }
 }
 
 impl Iterator for Shlex<'_> {
@@ -78,12 +92,6 @@ impl<'a> core::ops::Deref for Shlex<'a> {
 
     fn deref(&self) -> &Self::Target {
         &self.0
-    }
-}
-
-impl core::ops::DerefMut for Shlex<'_> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 

--- a/src/quoting_warning.md
+++ b/src/quoting_warning.md
@@ -30,8 +30,8 @@ Finally, there are some [solved issues](#solved-issues).
 ## Nul bytes
 
 For non-interactive shells, the most problematic input is nul bytes (bytes with value 0).  The
-non-deprecated functions all default to returning [`QuoteError::Nul`] when encountering them, but
-the deprecated [`quote`] and [`join`] functions leave them as-is.
+convenience functions all default to returning [`QuoteError::Nul`] when encountering them, but
+[`Quoter::allow_nul`] or [`bytes::Quoter::allow_nul`] can be used to leave them as-is.
 
 In Unix, nul bytes can't appear in command arguments, environment variables, or filenames.  It's
 not a question of proper quoting; they just can't be used at all.  This is a consequence of Unix's
@@ -42,13 +42,13 @@ Even when they do, it's pretty much useless or even dangerous, since you can't p
 external commands.
 
 In some cases, you might fail to pass the nul byte to the shell in the first place.  For example,
-the following code uses [`join`] to tunnel a command over an SSH connection:
+the following code uses [`Quoter::join`] to tunnel a command over an SSH connection:
 
 ```rust
 std::process::Command::new("ssh")
     .arg("myhost")
     .arg("--")
-    .arg(join(my_cmd_args))
+    .arg(Quoter::new().allow_nul(true).join(my_cmd_args).unwrap())
 ```
 
 If any argument in `my_cmd_args` contains a nul byte, then `join(my_cmd_args)` will contain a nul
@@ -360,6 +360,6 @@ separator.  Treatment as a word separator only happens for `b"\xa0"` alone, whic
 */
 
 // `use` declarations to make auto links work:
-use ::{quote, join, Shlex, Quoter, QuoteError};
+use ::{Shlex, Quoter, QuoteError};
 
 // TODO: add more about copy-paste and human readability.


### PR DESCRIPTION
Fixes #26. The unsound API is replaced with unsafe functions `Shlex::from_bytes` and `Shlex::as_bytes_mut`.

Since removing the unsound API is a breaking change, I took the opportunity to also remove deprecated items.