### PR TITLE
Fix rust docs not building

### DIFF
--- a/src/quoting_warning.md
+++ b/src/quoting_warning.md
@@ -360,6 +360,6 @@ separator.  Treatment as a word separator only happens for `b"\xa0"` alone, whic
 */
 
 // `use` declarations to make auto links work:
-use ::{Shlex, Quoter, QuoteError};
+use crate::{bytes, Shlex, Quoter, QuoteError};
 
 // TODO: add more about copy-paste and human readability.


### PR DESCRIPTION
I noticed that docs.rs failed to build for for the new 2.0 release: https://docs.rs/crate/shlex/latest/builds/3302978

This PR fixes that!