### PR TITLE
Build docs in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
       - run: rustup component add clippy
       - run: RUSTFLAGS=-Dwarnings cargo test
       - run: cargo clippy -- -Dwarnings
+      - run: cargo doc
       - run: RUSTFLAGS=-Dwarnings cargo build --manifest-path fuzz/Cargo.toml --all
 
   beta:


### PR DESCRIPTION
Avoids repeats of something like the bug fixed in #28.