### PR TITLE
Add a new os_str module

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -7,21 +7,19 @@
 //!
 //! This is used internally by the [outer module](crate), and may be more
 //! convenient if you are working with byte slices (`[u8]`) or types that are
-//! wrappers around bytes, such as [`OsStr`](std::ffi::OsStr):
+//! wrappers around bytes. If you need to work with [`OsStr`], use the
+//! [osstr module](crate::os_str).
 //!
 //! ```rust
-//! #[cfg(unix)] {
-//!     use shlex::bytes::try_quote;
-//!     use std::ffi::OsStr;
-//!     use std::os::unix::ffi::OsStrExt;
+//! use shlex::bytes::try_quote;
+//! use std::ffi::OsStr;
 //!
-//!     // `\x80` is invalid in UTF-8.
-//!     let os_str = OsStr::from_bytes(b"a\x80b c");
-//!     assert_eq!(try_quote(os_str.as_bytes()).unwrap(), &b"'a\x80b c'"[..]);
-//! }
+//! // `\x80` is invalid in UTF-8.
+//! let s = b"a\x80b c";
+//! assert_eq!(try_quote(s).unwrap(), &b"'a\x80b c'"[..]);
 //! ```
 //!
-//! (On Windows, `OsStr` uses 16 bit wide characters so this will not work.)
+//! [`OsStr`]: std::ffi::OsStr
 
 extern crate alloc;
 use alloc::vec::Vec;

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -167,7 +167,7 @@ pub fn split(in_bytes: &[u8]) -> Option<Vec<Vec<u8>>> {
 /// The string equivalent is [`shlex::Quoter`].
 #[derive(Default, Debug, Clone)]
 pub struct Quoter {
-    allow_nul: bool,
+    pub(crate) allow_nul: bool,
     // TODO: more options
 }
 
@@ -230,7 +230,7 @@ impl Quoter {
 }
 
 #[derive(PartialEq)]
-enum QuotingStrategy {
+pub(crate) enum QuotingStrategy {
     /// No quotes and no backslash escapes.  (If backslash escapes would be necessary, we use a
     /// different strategy instead.)
     Unquoted,
@@ -343,6 +343,36 @@ fn double_quoted_ok(c: u8) -> bool {
     }
 }
 
+pub(crate) const UNQUOTED_OK: u8 = 1;
+pub(crate) const SINGLE_QUOTED_OK: u8 = 2;
+pub(crate) const DOUBLE_QUOTED_OK: u8 = 4;
+
+pub(crate) fn check_char_quoting(c: u8, cur_ok: &mut u8) {
+    debug_assert!(c < 0x80);
+    if !unquoted_ok_fast(c) {
+        *cur_ok &= !UNQUOTED_OK;
+    }
+    if !single_quoted_ok(c) {
+        *cur_ok &= !SINGLE_QUOTED_OK;
+    }
+    if !double_quoted_ok(c) {
+        *cur_ok &= !DOUBLE_QUOTED_OK;
+    }
+}
+
+/// Pick the best allowed strategy.
+pub(crate) fn strategy_from_flags(prev_ok: u8) -> QuotingStrategy {
+    if prev_ok & UNQUOTED_OK != 0 {
+        QuotingStrategy::Unquoted
+    } else if prev_ok & SINGLE_QUOTED_OK != 0 {
+        QuotingStrategy::SingleQuoted
+    } else if prev_ok & DOUBLE_QUOTED_OK != 0 {
+        QuotingStrategy::DoubleQuoted
+    } else {
+        unreachable!()
+    }
+}
+
 /// Given an input, return a quoting strategy that can cover some prefix of the string, along with
 /// the size of that prefix.
 ///
@@ -350,10 +380,6 @@ fn double_quoted_ok(c: u8) -> bool {
 /// Postcondition: returned size is nonzero.
 #[cfg_attr(manual_codegen_check, inline(never))]
 fn quoting_strategy(in_bytes: &[u8]) -> (usize, QuotingStrategy) {
-    const UNQUOTED_OK: u8 = 1;
-    const SINGLE_QUOTED_OK: u8 = 2;
-    const DOUBLE_QUOTED_OK: u8 = 4;
-
     let mut prev_ok = SINGLE_QUOTED_OK | DOUBLE_QUOTED_OK | UNQUOTED_OK;
     let mut i = 0;
 
@@ -375,15 +401,7 @@ fn quoting_strategy(in_bytes: &[u8]) -> (usize, QuotingStrategy) {
             // has additional characters satisfying `isblank`.
             cur_ok &= !UNQUOTED_OK;
         } else {
-            if !unquoted_ok_fast(c) {
-                cur_ok &= !UNQUOTED_OK;
-            }
-            if !single_quoted_ok(c){
-                cur_ok &= !SINGLE_QUOTED_OK;
-            }
-            if !double_quoted_ok(c) {
-                cur_ok &= !DOUBLE_QUOTED_OK;
-            }
+            check_char_quoting(c, &mut cur_ok);
         }
 
         if cur_ok == 0 {
@@ -397,16 +415,7 @@ fn quoting_strategy(in_bytes: &[u8]) -> (usize, QuotingStrategy) {
         i += 1;
     }
 
-    // Pick the best allowed strategy.
-    let strategy = if prev_ok & UNQUOTED_OK != 0 {
-        QuotingStrategy::Unquoted
-    } else if prev_ok & SINGLE_QUOTED_OK != 0 {
-        QuotingStrategy::SingleQuoted
-    } else if prev_ok & DOUBLE_QUOTED_OK != 0 {
-        QuotingStrategy::DoubleQuoted
-    } else {
-        unreachable!()
-    };
+    let strategy = strategy_from_flags(prev_ok);
     debug_assert!(i > 0);
     (i, strategy)
 }
@@ -464,7 +473,7 @@ pub fn try_quote(in_bytes: &[u8]) -> Result<Cow<'_, [u8]>, QuoteError> {
 }
 
 #[cfg(test)]
-const INVALID_UTF8: &[u8] = b"\xa1";
+pub(crate) const INVALID_UTF8: &[u8] = b"\xa1";
 
 #[test]
 #[allow(invalid_from_utf8)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,9 +258,8 @@ fn test_lineno() {
     }
 }
 
-#[test]
-#[cfg_attr(not(feature = "std"), allow(unreachable_code, unused_mut))]
-fn test_quote() {
+#[cfg(test)]
+fn test_cases() -> impl Iterator<Item = (String, String)> {
     // This is a list of (unquoted, quoted) pairs.
     // But it's using a single long (raw) string literal with an ad-hoc format, just because it's
     // hard to read if we have to put the test strings through Rust escaping on top of the escaping
@@ -293,24 +292,36 @@ fn test_quote() {
         <'$>              => <"'"'$'>
         <"^>              => <'"''^'>
     "#;
-    let mut ok = true;
-    for test in tests.trim().split('\n') {
-        let parts: Vec<String> = test
-            .replace("NL", "\n")
+
+    tests.trim().split('\n').map(|test| {
+        let parts = test.replace("NL", "\n");
+        let mut parts = parts
             .split("=>")
-            .map(|part| part.trim().trim_start_matches('<').trim_end_matches('>').to_owned())
-            .collect();
-        assert!(parts.len() == 2);
-        let unquoted = &*parts[0];
-        let quoted_expected = &*parts[1];
-        let quoted_actual = try_quote(&parts[0]).unwrap();
+            .map(|part| part.trim().trim_start_matches('<').trim_end_matches('>'));
+        let unquoted = parts.next().unwrap();
+        let quoted_expected = parts.next().unwrap();
+        assert_eq!(parts.next(), None);
+        (unquoted.to_owned(), quoted_expected.to_owned())
+    })
+}
+
+#[test]
+#[cfg_attr(not(feature = "std"), allow(unreachable_code, unused_mut))]
+fn test_quote() {
+    let mut ok = true;
+    for (unquoted, quoted_expected) in test_cases() {
+        let quoted_actual = try_quote(&unquoted).unwrap();
         if quoted_expected != quoted_actual {
             #[cfg(not(feature = "std"))]
-            panic!("FAIL: for input <{}>, expected <{}>, got <{}>",
-                     unquoted, quoted_expected, quoted_actual);
+            panic!(
+                "FAIL: for input <{}>, expected <{}>, got <{}>",
+                unquoted, quoted_expected, quoted_actual
+            );
             #[cfg(feature = "std")]
-            println!("FAIL: for input <{}>, expected <{}>, got <{}>",
-                     unquoted, quoted_expected, quoted_actual);
+            println!(
+                "FAIL: for input <{}>, expected <{}>, got <{}>",
+                unquoted, quoted_expected, quoted_actual
+            );
             ok = false;
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,18 +291,30 @@ fn test_cases() -> impl Iterator<Item = (String, String)> {
         <a..b             => <a..b>
         <'$>              => <"'"'$'>
         <"^>              => <'"''^'>
+
+        # Some of the above with multibyte characters in the mix
+        <𝄞music>          => <'𝄞music'>
+        <NL💖>            => <'NL💖'>
+        <a,b,🏴‍☠️,d>         => <'a,b,🏴‍☠️,d'>
     "#;
 
-    tests.trim().split('\n').map(|test| {
-        let parts = test.replace("NL", "\n");
-        let mut parts = parts
-            .split("=>")
-            .map(|part| part.trim().trim_start_matches('<').trim_end_matches('>'));
-        let unquoted = parts.next().unwrap();
-        let quoted_expected = parts.next().unwrap();
-        assert_eq!(parts.next(), None);
-        (unquoted.to_owned(), quoted_expected.to_owned())
-    })
+    tests
+        .trim()
+        .split('\n')
+        .filter(|test| {
+            let trimmed = test.trim();
+            !trimmed.starts_with('#') && !trimmed.is_empty()
+        })
+        .map(|test| {
+            let parts = test.replace("NL", "\n");
+            let mut parts = parts
+                .split("=>")
+                .map(|part| part.trim().trim_start_matches('<').trim_end_matches('>'));
+            let unquoted = parts.next().unwrap();
+            let quoted_expected = parts.next().unwrap();
+            assert_eq!(parts.next(), None);
+            (unquoted.to_owned(), quoted_expected.to_owned())
+        })
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,8 @@ use alloc::vec;
 use alloc::borrow::ToOwned;
 
 pub mod bytes;
+#[cfg(all(feature = "std", any(windows, unix)))]
+pub mod os_str;
 #[cfg(all(doc, not(doctest)))]
 #[path = "quoting_warning.md"]
 pub mod quoting_warning;

--- a/src/os_str/bytestr.rs
+++ b/src/os_str/bytestr.rs
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: MIT OR Apache-2.0 */
+
+//! On Unix and WASI an `OsStr` is just a u8 slice, so we can use `bytes`.
+// FIXME: The WASI traits are currently not stable. Add support when available.
+
+use std::ffi::{OsStr, OsString};
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+use alloc::borrow::Cow;
+
+use crate::bytes;
+use crate::QuoteError;
+
+pub type Shlex<'a> = bytes::Shlex<'a>;
+
+pub fn shlex_new<'a>(in_str: &'a OsStr) -> Shlex<'a> {
+    bytes::Shlex::new(in_str.as_bytes())
+}
+
+pub fn shlex_next(this: &mut bytes::Shlex) -> Option<OsString> {
+    this.next().map(OsString::from_vec)
+}
+
+pub fn split(in_str: &OsStr) -> Option<Vec<OsString>> {
+    let mut shl = Shlex::new(in_str.as_bytes());
+    let res = shl.by_ref().map(OsString::from_vec).collect();
+    if shl.had_error {
+        None
+    } else {
+        Some(res)
+    }
+}
+
+pub fn join<'a, I: IntoIterator<Item = &'a OsStr>>(
+    quoter: &bytes::Quoter,
+    words: I,
+) -> Result<OsString, QuoteError> {
+    let words = words.into_iter().map(OsStr::as_bytes);
+    quoter.join(words).map(OsString::from_vec)
+}
+
+pub fn quote<'a>(quoter: &bytes::Quoter, in_str: &'a OsStr) -> Result<Cow<'a, OsStr>, QuoteError> {
+    match quoter.quote(in_str.as_bytes())? {
+        Cow::Borrowed(out) => Ok(OsStr::from_bytes(out).into()),
+        Cow::Owned(out) => Ok(OsString::from_vec(out).into()),
+    }
+}
+
+#[cfg(test)]
+pub fn extra_split_tests() -> Vec<(OsString, Vec<OsString>)> {
+    let invalid_utf8 = OsStr::from_bytes(bytes::INVALID_UTF8).to_owned();
+    vec![(invalid_utf8.clone(), vec![invalid_utf8])]
+}
+
+#[cfg(test)]
+pub fn extra_quote_tests() -> Vec<(OsString, OsString)> {
+    // This mostly exists for Windows
+    Vec::new()
+}

--- a/src/os_str/mod.rs
+++ b/src/os_str/mod.rs
@@ -1,0 +1,212 @@
+/* SPDX-License-Identifier: MIT OR Apache-2.0 */
+
+//! [`Shlex`] and friends for [`OsStr`].
+//!
+//! This can be used to split or join an `OsStr` directly. Unlike [`bytes`], the extension traits
+//! don't need to be used directly, and this is supported on Windows as well.
+//!
+//! Note that while this works on Windows, it still uses a POSIX syntax (like other `shlex`
+//! modules). This is likely sufficient for tasks like splitting environment variables, but
+//! results may not be appropriate for passing to Windows shells directly.
+//!
+//! This module is only available on platforms that have an `OsStrExt` and `OsStringExt`: currently
+//! only Unix and Windows.
+//!
+//! ```rust
+//! #[cfg(unix)] {
+//!     use shlex::bytes::try_quote;
+//!     use std::ffi::OsStr;
+//!     use std::os::unix::ffi::OsStrExt;
+//!
+//!     // `\x80` is invalid in UTF-8.
+//!     let os_str = OsStr::from_bytes(b"a\x80b c");
+//!     assert_eq!(try_quote(os_str.as_bytes()).unwrap(), &b"'a\x80b c'"[..]);
+//! }
+//!
+//! #[cfg(windows)] {
+//!     use shlex::os_str::try_quote;
+//!     use std::ffi::OsString;
+//!     use std::os::windows::ffi::OsStringExt;
+//!
+//!     // Wide char constructor
+//!     fn w(ch: u8) -> u16 { ch.into() }
+//!
+//!     // `\x80` is invalid in UTF-16.
+//!     let os_str = OsString::from_wide(&[w(b'a'), w(0x80), w(b'b'), w(b' '), w(b'c')]);
+//!     let expected = OsString::from_wide(
+//!         &[w(b'\''), w(b'a'), w(0x80), w(b'b'), w(b' '), w(b'c'), w(b'\'')]
+//!     );
+//!     assert_eq!(try_quote(&os_str).unwrap(), expected);
+//! }
+//! ```
+//!
+//! [`OsStr`]: std::ffi::OsStr
+
+#[cfg(unix)]
+#[path = "bytestr.rs"]
+mod imp;
+#[cfg(windows)]
+#[path = "widestr.rs"]
+mod imp;
+
+use std::ffi::{OsStr, OsString};
+
+use crate::bytes;
+#[cfg(all(doc, not(doctest)))]
+use crate::{self as shlex, quoting_warning};
+use alloc::borrow::Cow;
+use alloc::vec::Vec;
+
+use super::QuoteError;
+
+/// An iterator that takes an input byte string and splits it into the words using the same syntax
+/// as the POSIX shell.
+pub struct Shlex<'a>(imp::Shlex<'a>);
+
+impl<'a> Shlex<'a> {
+    pub fn new(in_str: &'a OsStr) -> Self {
+        Self(imp::shlex_new(in_str))
+    }
+}
+
+impl Iterator for Shlex<'_> {
+    type Item = OsString;
+    fn next(&mut self) -> Option<Self::Item> {
+        imp::shlex_next(&mut self.0)
+    }
+}
+
+/// Convenience function that consumes the whole byte string at once.  Returns None if the input was
+/// erroneous.
+pub fn split(in_str: &OsStr) -> Option<Vec<OsString>> {
+    imp::split(in_str)
+}
+
+/// A more configurable interface to quote strings.  If you only want the default settings you can
+/// use the convenience functions [`try_quote`] and [`try_join`].
+///
+/// The string equivalent is [`shlex::Quoter`].
+#[derive(Default, Debug, Clone)]
+pub struct Quoter {
+    inner: bytes::Quoter,
+}
+
+impl Quoter {
+    /// Create a new [`Quoter`] with default settings.
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set whether to allow [nul bytes](quoting_warning#nul-bytes).  By default they are not
+    /// allowed and will result in an error of [`QuoteError::Nul`].
+    #[inline]
+    pub fn allow_nul(mut self, allow: bool) -> Self {
+        self.inner = self.inner.allow_nul(allow);
+        self
+    }
+
+    /// Convenience function that consumes an iterable of words and turns it into a single byte
+    /// string, quoting words when necessary. Consecutive words will be separated by a single
+    /// space.
+    pub fn join<'a, I: IntoIterator<Item = &'a OsStr>>(
+        &self,
+        words: I,
+    ) -> Result<OsString, QuoteError> {
+        imp::join(&self.inner, words)
+    }
+
+    /// Given a single word, return a byte string suitable to encode it as a shell argument.
+    ///
+    /// If given a valid `OsStr`, this will never produce an invalid `OsStr`; see
+    /// [`bytes::Quoter::quote`] for details.
+    pub fn quote<'a>(&self, in_str: &'a OsStr) -> Result<Cow<'a, OsStr>, QuoteError> {
+        imp::quote(&self.inner, in_str)
+    }
+}
+
+/// Convenience function that consumes an iterable of words and turns it into a single `OsString`,
+/// quoting words when necessary. Consecutive words will be separated by a single space.
+///
+/// Uses default settings. The only error that can be returned is [`QuoteError::Nul`].
+///
+/// Equivalent to [`Quoter::new().join(words)`](Quoter).
+///
+/// The string equivalent is [shlex::try_join].
+pub fn try_join<'a, I: IntoIterator<Item = &'a OsStr>>(words: I) -> Result<OsString, QuoteError> {
+    Quoter::new().join(words)
+}
+
+/// Given a single word, return a string suitable to encode it as a shell argument.
+///
+/// Uses default settings. The only error that can be returned is [`QuoteError::Nul`].
+///
+/// Equivalent to [`Quoter::new().quote(in_bytes)`](Quoter).
+///
+/// The string equivalent is [shlex::try_quote].
+pub fn try_quote(in_str: &OsStr) -> Result<Cow<'_, OsStr>, QuoteError> {
+    Quoter::new().quote(in_str)
+}
+
+#[test]
+fn test_split() {
+    for &(input, output) in crate::SPLIT_TEST_ITEMS {
+        let input = OsStr::new(input);
+        assert_eq!(
+            split(input),
+            output.map(|o| o.iter().map(|&x| OsString::from(x)).collect())
+        );
+    }
+
+    for (input, output) in imp::extra_split_tests() {
+        assert_eq!(split(&input).unwrap(), output);
+    }
+}
+
+#[test]
+fn test_lineno() {
+    let mut sh = Shlex::new(OsStr::new("\nfoo\nbar"));
+    while let Some(word) = sh.next() {
+        if word == "bar" {
+            assert_eq!(sh.0.line_no, 3);
+        }
+    }
+}
+
+#[test]
+fn test_quote() {
+    let mut ok = true;
+    for (unquoted, quoted_expected) in crate::test_cases() {
+        let unquoted = OsStr::new(&unquoted);
+        let quoted_expected = OsStr::new(&quoted_expected);
+        let quoted_actual = try_quote(&unquoted).unwrap();
+        if quoted_expected != quoted_actual {
+            println!(
+                "FAIL: for input <{}>, expected <{}>, got <{}>",
+                unquoted.to_string_lossy(),
+                quoted_expected.to_string_lossy(),
+                quoted_actual.to_string_lossy()
+            );
+            ok = false;
+        }
+    }
+    for (unquoted, quoted_expected) in imp::extra_quote_tests() {
+        let quoted_actual = try_quote(&unquoted).unwrap();
+        if quoted_expected != quoted_actual {
+            println!(
+                "FAIL: for input <{}>, expected <{}>, got <{}>",
+                unquoted.to_string_lossy(),
+                quoted_expected.to_string_lossy(),
+                quoted_actual.to_string_lossy()
+            );
+            ok = false;
+        }
+    }
+    assert!(ok);
+}
+
+#[test]
+fn test_fallible() {
+    assert_eq!(try_join(vec![OsStr::new("\0")]), Err(QuoteError::Nul));
+    assert_eq!(try_quote(OsStr::new("\0")), Err(QuoteError::Nul));
+}

--- a/src/os_str/widestr.rs
+++ b/src/os_str/widestr.rs
@@ -1,0 +1,348 @@
+/* SPDX-License-Identifier: MIT OR Apache-2.0 */
+
+//! On Windows, an `OsStr` is a byte-encoded string with 16-bit characters. Transcoding is
+//! required so this API is more iterator-based.
+
+use core::iter;
+use std::ffi::{OsStr, OsString};
+
+use alloc::borrow::Cow;
+
+use crate::bytes::{self, strategy_from_flags, DOUBLE_QUOTED_OK, SINGLE_QUOTED_OK, UNQUOTED_OK};
+use crate::bytes::{check_char_quoting, QuotingStrategy};
+use crate::QuoteError;
+
+use std::os::windows::ffi::{EncodeWide, OsStrExt, OsStringExt};
+
+type OsIter<'a> = EncodeWide<'a>;
+
+const NUL: u16 = '\0' as u16;
+const SPACE: u16 = ' ' as u16;
+const DOLLAR: u16 = '$' as u16;
+const HASH: u16 = '#' as u16;
+const NEWLINE: u16 = '\n' as u16;
+const TAB: u16 = '\t' as u16;
+const DOUBLE_QUOTE: u16 = '"' as u16;
+const SINGLE_QUOTE: u16 = '\'' as u16;
+const BACKSLASH: u16 = '\\' as u16;
+const BACKTICK: u16 = '`' as u16;
+
+/// An iterator that takes an input byte string and splits it into the words using the same syntax as
+/// the POSIX shell.
+pub struct Shlex<'a> {
+    in_iter: EncodeWide<'a>,
+    /// The number of newlines read so far, plus one.
+    pub line_no: usize,
+    /// An input string is erroneous if it ends while inside a quotation or right after an
+    /// unescaped backslash.  Since Iterator does not have a mechanism to return an error, if that
+    /// happens, Shlex just throws out the last token, ends the iteration, and sets 'had_error' to
+    /// true; best to check it after you're done iterating.
+    had_error: bool,
+}
+
+impl<'a> Shlex<'a> {
+    fn parse_word(&mut self, mut ch: u16) -> Option<OsString> {
+        let mut result: Vec<u16> = Vec::new();
+        loop {
+            match ch {
+                DOUBLE_QUOTE => {
+                    if let Err(()) = self.parse_double(&mut result) {
+                        self.had_error = true;
+                        return None;
+                    }
+                }
+                SINGLE_QUOTE => {
+                    if let Err(()) = self.parse_single(&mut result) {
+                        self.had_error = true;
+                        return None;
+                    }
+                }
+                BACKSLASH => {
+                    if let Some(ch2) = self.next_char() {
+                        if ch2 != NEWLINE {
+                            result.push(ch2);
+                        }
+                    } else {
+                        self.had_error = true;
+                        return None;
+                    }
+                }
+                SPACE | TAB | NEWLINE => break,
+                _ => result.push(ch),
+            }
+            if let Some(ch2) = self.next_char() {
+                ch = ch2;
+            } else {
+                break;
+            }
+        }
+        Some(OsString::from_wide(&result))
+    }
+
+    fn parse_double(&mut self, result: &mut Vec<u16>) -> Result<(), ()> {
+        loop {
+            if let Some(ch2) = self.next_char() {
+                match ch2 {
+                    BACKSLASH => {
+                        if let Some(ch3) = self.next_char() {
+                            match ch3 {
+                                // \$ => $
+                                DOLLAR | BACKTICK | DOUBLE_QUOTE | BACKSLASH => result.push(ch3),
+                                // \<newline> => nothing
+                                NEWLINE => {}
+                                // \x => =x
+                                _ => {
+                                    result.push(b'\\'.into());
+                                    result.push(ch3);
+                                }
+                            }
+                        } else {
+                            return Err(());
+                        }
+                    }
+                    DOUBLE_QUOTE => return Ok(()),
+                    _ => result.push(ch2),
+                }
+            } else {
+                return Err(());
+            }
+        }
+    }
+
+    fn parse_single(&mut self, result: &mut Vec<u16>) -> Result<(), ()> {
+        loop {
+            if let Some(ch2) = self.next_char() {
+                match ch2 {
+                    SINGLE_QUOTE => return Ok(()),
+                    _ => result.push(ch2),
+                }
+            } else {
+                return Err(());
+            }
+        }
+    }
+
+    fn next_char(&mut self) -> Option<u16> {
+        let res = self.in_iter.next();
+        if res == Some(NEWLINE) {
+            self.line_no += 1;
+        }
+        res
+    }
+}
+
+impl Iterator for Shlex<'_> {
+    type Item = OsString;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(mut ch) = self.next_char() {
+            // skip initial whitespace
+            loop {
+                match ch {
+                    SPACE | TAB | NEWLINE => {}
+                    HASH => {
+                        while let Some(ch2) = self.next_char() {
+                            if ch2 == NEWLINE {
+                                break;
+                            }
+                        }
+                    }
+                    _ => break,
+                }
+                if let Some(ch2) = self.next_char() {
+                    ch = ch2;
+                } else {
+                    return None;
+                }
+            }
+            self.parse_word(ch)
+        } else {
+            // no initial character
+            None
+        }
+    }
+}
+
+pub fn shlex_new<'a>(in_str: &'a OsStr) -> Shlex<'a> {
+    Shlex {
+        in_iter: in_str.encode_wide(),
+        line_no: 1,
+        had_error: false,
+    }
+}
+
+pub fn shlex_next(this: &mut Shlex) -> Option<OsString> {
+    this.next()
+}
+
+pub fn split(in_str: &OsStr) -> Option<Vec<OsString>> {
+    let mut shl = shlex_new(in_str);
+    let res = shl.by_ref().collect();
+    if shl.had_error {
+        None
+    } else {
+        Some(res)
+    }
+}
+
+pub fn join<'a, I: IntoIterator<Item = &'a OsStr>>(
+    quoter: &bytes::Quoter,
+    words: I,
+) -> Result<OsString, QuoteError> {
+    let quoted_words = words.into_iter().map(|word| quote(quoter, word));
+
+    let mut ret = OsString::new();
+    let mut first = true;
+    for word in quoted_words {
+        if !first {
+            ret.push(" ");
+        }
+        first = true;
+        ret.push(word?);
+    }
+
+    Ok(ret)
+}
+
+pub fn quote<'a>(quoter: &bytes::Quoter, in_str: &'a OsStr) -> Result<Cow<'a, OsStr>, QuoteError> {
+    if in_str.is_empty() {
+        // Empty string.  Special case that isn't meaningful as only part of a word.
+        return Ok(OsStr::new("''").into());
+    }
+
+    if !quoter.allow_nul && in_str.encode_wide().any(|ch| ch == NUL) {
+        return Err(QuoteError::Nul);
+    }
+
+    let mut iter = in_str.encode_wide();
+    let mut out: Vec<u16> = Vec::new();
+
+    while iter.clone().next().is_some() {
+        // Pick a quoting strategy for some prefix of the input.  Normally this will cover the
+        // entire input, but in some case we might need to divide the input into multiple chunks
+        // that are quoted differently.
+        let (cur_len, strategy) = quoting_strategy(iter.clone());
+        if cur_len == in_str.len() && strategy == QuotingStrategy::Unquoted && out.is_empty() {
+            // Entire string can be represented unquoted.  Reuse the allocation.
+            return Ok(in_str.into());
+        }
+
+        append_quoted_chunk(&mut out, (&mut iter).take(cur_len), strategy);
+    }
+
+    Ok(OsString::from_wide(&out).into())
+}
+
+#[cfg_attr(manual_codegen_check, inline(never))]
+fn quoting_strategy(mut iter: EncodeWide) -> (usize, QuotingStrategy) {
+    let mut prev_ok = SINGLE_QUOTED_OK | DOUBLE_QUOTED_OK | UNQUOTED_OK;
+
+    let mut i = 0;
+
+    while let Some(c) = iter.next() {
+        if i == 0 && c == u16::from(b'^') {
+            // To work around a Bash bug, ^ is only allowed right after an opening single quote; see
+            // quoting_warning.
+            prev_ok = SINGLE_QUOTED_OK;
+            i += 1;
+            continue;
+        }
+
+        let mut cur_ok = prev_ok;
+
+        if c >= 0x80 {
+            // Normally, non-ASCII characters shouldn't require quoting, but see quoting_warning.md
+            // about \xa0.  For now, just treat all non-ASCII characters as requiring quotes.  This
+            // also ensures things are safe in the off-chance that you're in a legacy 8-bit locale that
+            // has additional characters satisfying `isblank`.
+            cur_ok &= !UNQUOTED_OK;
+        } else {
+            check_char_quoting(c as u8, &mut cur_ok);
+        }
+
+        if cur_ok == 0 {
+            // There are no quoting strategies that would work for both the previous characters and
+            // this one.  So we have to end the chunk before this character.  The caller will call
+            // `quoting_strategy` again to handle the rest of the string.
+            break;
+        }
+
+        prev_ok = cur_ok;
+        i += 1;
+    }
+
+    let strategy = strategy_from_flags(prev_ok);
+    debug_assert!(i > 0);
+    (i, strategy)
+}
+
+fn append_quoted_chunk(
+    out: &mut Vec<u16>,
+    iter: iter::Take<&mut OsIter>,
+    strategy: QuotingStrategy,
+) {
+    match strategy {
+        QuotingStrategy::Unquoted => out.extend(iter),
+        QuotingStrategy::SingleQuoted => {
+            let (lower, upper) = iter.size_hint();
+            out.reserve(upper.unwrap_or(lower) + 2);
+            out.push(b'\''.into());
+            out.extend(iter);
+            out.push(b'\''.into());
+        }
+        QuotingStrategy::DoubleQuoted => {
+            let (lower, upper) = iter.size_hint();
+            out.reserve(upper.unwrap_or(lower) + 2);
+            out.push(b'"'.into());
+            for c in iter {
+                if let DOLLAR | BACKTICK | DOUBLE_QUOTE | BACKSLASH = c {
+                    // Add a preceding backslash.
+                    // Note: We shouldn't actually get here for $ and ` because they don't pass
+                    // `double_quoted_ok`.
+                    out.push(b'\\'.into());
+                }
+                // Add the character itself.
+                out.push(c);
+            }
+            out.push(b'"'.into());
+        }
+    }
+}
+
+#[cfg(test)]
+pub fn extra_split_tests() -> Vec<(OsString, Vec<OsString>)> {
+    let invalid_utf8 = OsString::from_wide(&[bytes::INVALID_UTF8[0].into()]);
+
+    // From the `String::from_utf16` examples
+    let good16 = &[0xD834, 0xDD1E, 0x006d, 0x0075, 0x0073, 0x0069, 0x0063];
+    let bad16 = &[0xD834, 0xDD1E, 0x006d, 0x0075, 0xD800, 0x0069, 0x0063];
+    assert!(String::from_utf16(good16).is_ok());
+    assert!(String::from_utf16(bad16).is_err());
+    let valid_utf16 = OsString::from_wide(good16);
+    let invalid_utf16 = OsString::from_wide(bad16);
+
+    vec![
+        (invalid_utf8.clone(), vec![invalid_utf8]),
+        (invalid_utf16.clone(), vec![invalid_utf16]),
+        (valid_utf16.clone(), vec![valid_utf16]),
+    ]
+}
+
+#[cfg(test)]
+pub fn extra_quote_tests() -> Vec<(OsString, OsString)> {
+    let mut ret = Vec::new();
+    let mut buf = Vec::new();
+
+    // Just make sure things still work with UTF-16
+    for (unquoted, quoted_expected) in crate::test_cases() {
+        buf.clear();
+        buf.extend(unquoted.encode_utf16());
+        let unquoted = OsString::from_wide(&buf);
+        buf.clear();
+        buf.extend(quoted_expected.encode_utf16());
+        let quoted_expected = OsString::from_wide(&buf);
+        ret.push((unquoted, quoted_expected));
+    }
+
+    ret
+}


### PR DESCRIPTION
Introduce a new module for working with `OsStr`. On Unix this is pretty easy, just a wrapper around `bytes`. On Windows this needs a wrapper around the `EncodeWide` iterator and some changes to support `u16`.